### PR TITLE
patch to include credential_types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "idkit"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "alloy-sol-types",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "idkit"
 edition = "2021"
 license = "MIT"
-version = "0.1.0"
+version = "0.1.1"
 readme = "README.md"
 authors = ["Miguel Piedrafita <rust@miguel.build>"]
 repository = "https://github.com/worldcoin/idkit-rs"

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -115,6 +115,7 @@ impl Session {
 					"action": action,
 					"action_description": action_description,
 					"signal": format!("0x{:x}", encode_signal(&signal)),
+					"credential_types": Self::verification_level_to_credential_types(verification_level),
 					"verification_level": verification_level.to_string(),
 				}),
 			)?)
@@ -234,5 +235,22 @@ impl Session {
 			.map_err(|_| Error::Encryption("Failed to decrypt bridge response"))?;
 
 		Ok(serde_json::from_slice(payload)?)
+	}
+
+	fn verification_level_to_credential_types(verification_level: VerificationLevel) -> Vec<CredentialType> {
+		if verification_level == VerificationLevel::Device {
+			return vec![
+				// format!("{}", CredentialType::Orb),
+				// format!("{}", CredentialType::Device),
+				CredentialType::Orb,
+				CredentialType::Device,
+			]
+		}
+		else { 
+			return vec![
+				// format!("{}", CredentialType::Orb),
+				CredentialType::Orb,
+			]
+		}
 	}
 }

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -240,15 +240,12 @@ impl Session {
 	fn verification_level_to_credential_types(verification_level: VerificationLevel) -> Vec<CredentialType> {
 		if verification_level == VerificationLevel::Device {
 			return vec![
-				// format!("{}", CredentialType::Orb),
-				// format!("{}", CredentialType::Device),
 				CredentialType::Orb,
 				CredentialType::Device,
 			]
 		}
 		else { 
 			return vec![
-				// format!("{}", CredentialType::Orb),
 				CredentialType::Orb,
 			]
 		}

--- a/src/session/types.rs
+++ b/src/session/types.rs
@@ -11,6 +11,15 @@ pub enum CredentialType {
 	Device,
 }
 
+impl Display for CredentialType {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match self {
+			Self::Orb => write!(f, "orb"),
+			Self::Device => write!(f, "device"),
+		}
+	}
+}
+
 /// The minimum verification level accepted.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "lowercase")]


### PR DESCRIPTION
our hackathon patch
without that field, client is always assumed to be "orb", not the "device"