### PR TITLE
Add `credential_types` field to payload.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "idkit"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "alloy-sol-types",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "idkit"
 edition = "2021"
 license = "MIT"
-version = "0.1.0"
+version = "0.1.1"
 readme = "README.md"
 authors = ["Miguel Piedrafita <rust@miguel.build>"]
 repository = "https://github.com/worldcoin/idkit-rs"

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -115,6 +115,7 @@ impl Session {
 					"action": action,
 					"action_description": action_description,
 					"signal": format!("0x{:x}", encode_signal(&signal)),
+					"credential_types": verification_level.to_credential_types(),
 					"verification_level": verification_level.to_string(),
 				}),
 			)?)

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -115,8 +115,8 @@ impl Session {
 					"action": action,
 					"action_description": action_description,
 					"signal": format!("0x{:x}", encode_signal(&signal)),
-					"credential_types": verification_level.to_credential_types(),
 					"verification_level": verification_level.to_string(),
+					"credential_types": verification_level.to_credential_types(),
 				}),
 			)?)
 			.send()

--- a/src/session/types.rs
+++ b/src/session/types.rs
@@ -35,7 +35,7 @@ impl Display for VerificationLevel {
 }
 
 impl VerificationLevel {
-    #[must_use]
+	#[must_use]
 	pub fn to_credential_types(&self) -> Vec<CredentialType> {
 		match self {
 			Self::Orb => vec![CredentialType::Orb],

--- a/src/session/types.rs
+++ b/src/session/types.rs
@@ -34,6 +34,16 @@ impl Display for VerificationLevel {
 	}
 }
 
+impl VerificationLevel {
+    #[must_use]
+	pub fn to_credential_types(&self) -> Vec<CredentialType> {
+		match self {
+			Self::Orb => vec![CredentialType::Orb],
+			Self::Device => vec![CredentialType::Orb, CredentialType::Device],
+		}
+	}
+}
+
 /// The error returned by the World App.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize, thiserror::Error)]
 #[serde(rename_all = "snake_case")]


### PR DESCRIPTION
# Description
As mentioned in #2 , if the `credential_types` field is missing from the `request` payload, it defaults to `orb`, even if `VerificationLevel` is set to `Device`. Therefore, the user&mdash;who isn't verified by an Orb yet&mdash;is prompted by a "You need to be verified by Orb to proceed this" error message. See image below.
![world-id](https://github.com/worldcoin/idkit-rs/assets/48633076/f7da7cb2-5c07-4a5f-9c37-6b855acf1e62)

Since #2 seems to be abandoned, I thought I'll open this PR as I also need this issue to be fixed.