### PR TITLE
Add new verification levels; fix hashing tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target
+.idea
+.DS_Store

--- a/src/hashing.rs
+++ b/src/hashing.rs
@@ -48,7 +48,11 @@ mod tests {
 			.unwrap()
 		);
 		assert_eq!(
-			format!("0x{:x}", hash_to_field(b"test")),
+			format!("0x{:064x}", hash_to_field(b"hello world")),
+			"0x0047173285a8d7341e5e972fc677286384f802f8ef42a5ec5f03bbfa254cb01f"
+		);
+		assert_eq!(
+			format!("0x{:064x}", hash_to_field(b"test")),
 			"0x009c22ff5f21f0b81b113e63f7db6da94fedef11b2119b4088b89664fb9a3cb6"
 		);
 	}
@@ -56,15 +60,15 @@ mod tests {
 	#[test]
 	fn test_encode_signal() {
 		assert_eq!(
-			format!("0x{:x}", encode_signal(&"test")),
+			format!("0x{:064x}", encode_signal(&"test")),
 			"0x009c22ff5f21f0b81b113e63f7db6da94fedef11b2119b4088b89664fb9a3cb6"
 		);
 		assert_eq!(
-			format!("0x{:x}", encode_signal(&(U256::from(1), "test"))),
+			format!("0x{:064x}", encode_signal(&(U256::from(1), "test"))),
 			"0x0088c8c90482320f18b0c0842feaeab88065fd7ef3ef7b06066af823d8eef6f9"
 		);
 		assert_eq!(
-			format!("0x{:x}", encode_signal::<()>(&())),
+			format!("0x{:064x}", encode_signal::<()>(&())),
 			"0x00c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a4"
 		);
 	}

--- a/src/session/types.rs
+++ b/src/session/types.rs
@@ -60,7 +60,11 @@ impl VerificationLevel {
 			Self::Orb => vec![CredentialType::Orb],
 			Self::Device => vec![CredentialType::Orb, CredentialType::Device],
 			Self::SecureDocument => vec![CredentialType::Orb, CredentialType::SecureDocument],
-			Self::Document => vec![CredentialType::Orb, CredentialType::Document, CredentialType::SecureDocument],
+			Self::Document => vec![
+				CredentialType::Orb,
+				CredentialType::Document,
+				CredentialType::SecureDocument
+			],
 		}
 	}
 }

--- a/src/session/types.rs
+++ b/src/session/types.rs
@@ -63,7 +63,7 @@ impl VerificationLevel {
 			Self::Document => vec![
 				CredentialType::Orb,
 				CredentialType::Document,
-				CredentialType::SecureDocument
+				CredentialType::SecureDocument,
 			],
 		}
 	}

--- a/src/session/types.rs
+++ b/src/session/types.rs
@@ -10,6 +10,8 @@ const DEFAULT_BRIDGE_URL: &str = "https://bridge.worldcoin.org";
 #[serde(rename_all = "lowercase")]
 pub enum CredentialType {
 	Orb,
+	SecureDocument,
+	Document,
 	Device,
 }
 
@@ -17,6 +19,8 @@ impl From<CredentialType> for VerificationLevel {
 	fn from(val: CredentialType) -> Self {
 		match val {
 			CredentialType::Orb => Self::Orb,
+			CredentialType::SecureDocument => Self::SecureDocument,
+			CredentialType::Document => Self::Document,
 			CredentialType::Device => Self::Device,
 		}
 	}
@@ -27,6 +31,8 @@ impl From<CredentialType> for VerificationLevel {
 #[serde(rename_all = "lowercase")]
 pub enum VerificationLevel {
 	Orb,
+	SecureDocument,
+	Document,
 	Device,
 }
 
@@ -40,6 +46,8 @@ impl Display for VerificationLevel {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		match self {
 			Self::Orb => write!(f, "orb"),
+			Self::SecureDocument => write!(f, "secure_document"),
+			Self::Document => write!(f, "document"),
 			Self::Device => write!(f, "device"),
 		}
 	}
@@ -50,6 +58,12 @@ impl VerificationLevel {
 	pub fn to_credential_types(&self) -> Vec<CredentialType> {
 		match self {
 			Self::Orb => vec![CredentialType::Orb],
+			Self::SecureDocument => vec![CredentialType::Orb, CredentialType::SecureDocument],
+			Self::Document => vec![
+				CredentialType::Document,
+				CredentialType::SecureDocument,
+				CredentialType::Orb,
+			],
 			Self::Device => vec![CredentialType::Orb, CredentialType::Device],
 		}
 	}

--- a/src/session/types.rs
+++ b/src/session/types.rs
@@ -10,18 +10,18 @@ const DEFAULT_BRIDGE_URL: &str = "https://bridge.worldcoin.org";
 #[serde(rename_all = "lowercase")]
 pub enum CredentialType {
 	Orb,
-	SecureDocument,
-	Document,
 	Device,
+	Document,
+	SecureDocument,
 }
 
 impl From<CredentialType> for VerificationLevel {
 	fn from(val: CredentialType) -> Self {
 		match val {
 			CredentialType::Orb => Self::Orb,
-			CredentialType::SecureDocument => Self::SecureDocument,
-			CredentialType::Document => Self::Document,
 			CredentialType::Device => Self::Device,
+			CredentialType::Document => Self::Document,
+			CredentialType::SecureDocument => Self::SecureDocument,
 		}
 	}
 }
@@ -31,9 +31,9 @@ impl From<CredentialType> for VerificationLevel {
 #[serde(rename_all = "lowercase")]
 pub enum VerificationLevel {
 	Orb,
-	SecureDocument,
-	Document,
 	Device,
+	Document,
+	SecureDocument,
 }
 
 impl Default for VerificationLevel {
@@ -46,9 +46,9 @@ impl Display for VerificationLevel {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		match self {
 			Self::Orb => write!(f, "orb"),
-			Self::SecureDocument => write!(f, "secure_document"),
-			Self::Document => write!(f, "document"),
 			Self::Device => write!(f, "device"),
+			Self::Document => write!(f, "document"),
+			Self::SecureDocument => write!(f, "secure_document"),
 		}
 	}
 }
@@ -58,13 +58,9 @@ impl VerificationLevel {
 	pub fn to_credential_types(&self) -> Vec<CredentialType> {
 		match self {
 			Self::Orb => vec![CredentialType::Orb],
-			Self::SecureDocument => vec![CredentialType::Orb, CredentialType::SecureDocument],
-			Self::Document => vec![
-				CredentialType::Document,
-				CredentialType::SecureDocument,
-				CredentialType::Orb,
-			],
 			Self::Device => vec![CredentialType::Orb, CredentialType::Device],
+			Self::SecureDocument => vec![CredentialType::Orb, CredentialType::SecureDocument],
+			Self::Document => vec![CredentialType::Orb, CredentialType::Document, CredentialType::SecureDocument],
 		}
 	}
 }


### PR DESCRIPTION
* Adds new verification levels `document` and `secure document`
* Fixes failing hashing tests by padding the output to 64 characters, as is done in the [idkit-js](https://github.com/worldcoin/idkit-js/blob/main/packages/core/src/lib/hashing.ts#L59)

similar to:
* https://github.com/worldcoin/idkit-kotlin/pull/2
* https://github.com/worldcoin/idkit-swift/pull/2